### PR TITLE
Fix for latest updates to prompt-toolkit (2.0.7)

### DIFF
--- a/engine/Exploiter.py
+++ b/engine/Exploiter.py
@@ -4,7 +4,7 @@ import importlib
 import json
 
 from prompt_toolkit import prompt
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import prompt
 

--- a/engine/Parser.py
+++ b/engine/Parser.py
@@ -32,7 +32,7 @@ class Parser:
         parser.add_argument("--themes", help="theme enumeration", action="store_true")
         parser.add_argument("--version", type=float, help="Drupal version")
         parser.add_argument("--cookies", type=str, help="cookies")
-        parser.add_argument("--thread", type=int, help="threads number")
+        parser.add_argument("--thread", type=int, default=20, help="threads number")
         parser.add_argument("--range", type=int, help="enumeration range")
         parser.add_argument("--ua", type=str, help="User Agent")
         parser.add_argument("--bauth", type=str, help="Basic authentication")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 pysocks
 veryprettytable
-prompt_toolkit<=1.0.15
+prompt_toolkit<=2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 pysocks
 veryprettytable
-prompt_toolkit<=2.0.7
+prompt_toolkit>=2.0.7

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=['requests', 'veryprettytable', 'prompt_toolkit <= 1.0.15', 'pysocks'],
+    install_requires=['requests', 'veryprettytable', 'prompt_toolkit <= 2.0.7', 'pysocks'],
     python_requires='>=3',
     scripts=['drupwn']
 )


### PR DESCRIPTION
Prompt-toolkit made a breaking change to it's layout, moving the `WordCompletion` base class into `prompt-toolkit.completion` causing drupwn to break when prompt-tookit>1.0.15 onwards is installed.

I've implemented a fix that requires the latest prompt-toolkit but does not pin the version so as to not restrict user environments. (Installing in a pipenv is probably the best idea anyway...)

I also took the liberty of setting a default thread count in the parser because the tool runs outrageously slow in enum mode without it. I figured 20 threads was reasonable.

Regards,
-- TrueDemon

