### PR TITLE
Do not leave apk cache behind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:latest
 
-RUN apk update
-RUN apk add python3
+RUN apk add --no-cache python3
 
 ADD . /opt/drupwn
 


### PR DESCRIPTION
This reduces the final image size, prevents outdated caches and is a best practice.