### PR TITLE
Fixed Dockerfile by adding setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:latest
 
 RUN apk update
-RUN apk add python3
+RUN apk add --no-cache python3 \ 
+	&& apk add --no-cache py3-setuptools
 
 ADD . /opt/drupwn
 


### PR DESCRIPTION
The Dockerfile failed to compile as it was missing `setuptools`, I added an install line for setup tools and disabled cache to reduce the overall image size. 